### PR TITLE
240612_06_이기영

### DIFF
--- a/lib/06_polymorphism/assingment.dart
+++ b/lib/06_polymorphism/assingment.dart
@@ -1,0 +1,79 @@
+class A extends Y {
+  @override
+  void a() {
+    print('Aa');
+  }
+
+  @override
+  void b() {
+    print('ab');
+  }
+
+  void c() {
+    print('Ac');
+  }
+}
+
+class B extends Y {
+  @override
+  void a() {
+    print('Ba');
+  }
+
+  @override
+  void b() {
+    print('Bb');
+  }
+
+  void c() {
+    print('Bc');
+  }
+}
+
+abstract interface class X {
+  void a();
+}
+
+abstract class Y implements X {
+  void b();
+}
+
+/*
+이런 클래스가 선언되어 있다.
+다음 물음에 답하시오
+
+X obj = A(); 로 A인스턴스를 생성한 후, 변수 obj에서 호출할 수 있는 메소드를 a(), b(), c() 중에 골라보시오
+-> a, b, c -> a만 가능
+Y y1 = A();
+Y y2 = B(); 로 A와 B의 인스턴스를 생성한 후
+y1.a();
+-> Aa
+y2.a(); 를 실행했을 때에 화면에 표시되는 내용을 말하시오.
+-> Ba
+*/
+
+/*
+문제 2 에서 이용한 A클래스나 B클래스의 인스턴스를 각각 1개씩 생성하여, List 에 차례로 담는다.
+그 후에 List 의 요소를 차례대로 꺼내 각각의 인스턴스의 b() 메소드를 호출 하여야 한다. 이상을 전제로 다음 물음에 답하시오.
+1. List 변수의 타입으로 무엇을 사용하여야 하는가
+-> A와 B가 모두 부모를 갖는 상위 인터페이스나 클래스
+2. 위에서 설명하고 있는 프로그램을 작성하시오
+ */
+void main() {
+  // 연습문제 2
+  print('연습문제 2');
+  X obj = A();
+  obj.a();
+
+  Y y1 = A();
+  Y y2 = B();
+  y1.a();
+  y2.a();
+
+  // 연습문제 3
+  print('연습문제 3');
+  A a = A();
+  B b = B();
+  List<Y> list = [a, b];
+  list.forEach((it) => it.b());
+}

--- a/lib/06_polymorphism/poly_pratice.dart
+++ b/lib/06_polymorphism/poly_pratice.dart
@@ -1,0 +1,35 @@
+class Slime extends Monster {
+  int hp = 50;
+  final String suffix;
+
+  Slime(this.suffix);
+
+  @override
+  void run() {
+    print('슬라임 도망침');
+  }
+
+  void attack() {
+    print('공격');
+  }
+}
+
+abstract class Monster {
+  void run() {
+    print('monster');
+  }
+}
+
+void main() {
+  Slime slime = Slime('A');
+  Monster monster = Slime('B');
+  Monster newMonster = slime;
+
+  // 결과는 모두 slime의 run이 실행된다.
+  slime.run();
+  monster.run();
+
+  // newMonster는 attack을 모른다.
+  slime.attack();
+  // newMonster.attack();
+}

--- a/lib/06_polymorphism/starcraft/giyoung_starcraft.puml
+++ b/lib/06_polymorphism/starcraft/giyoung_starcraft.puml
@@ -1,0 +1,111 @@
+@startuml
+
+abstract class Object {
+    + int hp
+    + int maxHp
+}
+
+interface Structure extends Object {
+    + void generate(Unit unit)
+}
+
+abstract class Unit extends Object {
+     + void move()
+ }
+
+abstract class AttackUnit extends Unit {
+    + int damage
+
+    + void attack(Unit unit))
+}
+
+abstract class MagicUnit extends Unit {
+    + int mp
+
+    + void useMagic({Unit unit)})
+}
+
+abstract class Terran {}
+
+abstract class Protoss {
+    + int shield
+    + int maxShield
+
+    + void chargeShield()
+}
+
+abstract class Zerg {
+  + void selfAid()
+}
+
+interface Bionic {}
+interface Mechanic {}
+
+class Marine extends Terran implements AttackUnit, Bionic {
+   + int hp
+   + int maxHp
+   + int damage
+
+   + void attack(Unit unit))
+   + void move()
+}
+
+class Medic extends Terran implements MagicUnit, Bionic {
+   + int hp
+   + int mp
+   + int maxHp
+   + int maxMp
+
+   + void move()
+   + void useMagic({Unit unit)})
+   + void heal()
+}
+
+class Scv extends Terran implements AttackUnit, Bionic, Mechanic {
+   + int hp
+   + int maxHp
+   + int damage
+
+   + void move()
+   + void attack(Unit unit))
+   + void containMineral()
+   + void repair(Unit unit))
+}
+
+class Zealot extends Protoss implements AttackUnit, Bionic {
+   + int hp
+   + int maxHp
+   + int shield
+   + int maxShield
+   + int damage
+
+   + void move()
+   + void attack(Unit unit))
+   + void chargeShield()
+}
+
+class Dragun extends Protoss implements AttackUnit, Mechanic {
+   + int hp
+   + int maxHp
+   + int shield
+   + int maxShield
+   + int damage
+
+   + void move()
+   + void attack(Unit unit))
+   + void chargeShield()
+}
+
+class Zergling extends Zerg implements AttackUnit, Bionic {
+   + int hp
+   + int maxHp
+   + int damage
+
+   + void move()
+   + void attack(Unit unit))
+   + void selfAid()
+}
+
+
+
+@enduml

--- a/lib/06_polymorphism/starcraft/main.dart
+++ b/lib/06_polymorphism/starcraft/main.dart
@@ -1,0 +1,52 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/object/unit/protoss/dragun.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/object/unit/terran/marine.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/object/unit/terran/medic.dart';
+
+import 'object/unit/protoss/zealot.dart';
+import 'object/unit/terran/scv.dart';
+import 'type/unit_type/unit.dart';
+
+void main() {
+  // 원래는 test_code 작성하여 test 해야하나....
+  Zealot z = Zealot();
+  z.hp = 5;
+  z.shield = 5;
+  z.chargeShield();
+  print('질럿의 hp : ${z.hp}');
+  print('질럿의 쉴드 : ${z.shield}');
+
+  Medic medic = Medic();
+  medic.heal(z);
+  print('heal 후 질럿의 hp : ${z.hp}');
+
+  Dragun dragun = Dragun();
+  dragun.hp = 1;
+  medic.heal(dragun);
+  print('heal 후 drgun의 hp : ${dragun.hp}');
+
+  Scv scv = Scv();
+  scv.hp = 1;
+  medic.heal(scv);
+  print('heal 후 scv의 hp : ${scv.hp}');
+
+  Scv powerScv = Scv();
+  powerScv.repair(scv);
+  print('수리 후 scv의 hp : ${scv.hp}');
+
+  // 자가치료 테스트
+  powerScv.repair(powerScv);
+
+  // 그룹화 테스트
+  int idx = 0;
+  List<Unit> group = [];
+  while (idx < 10) {
+    if (idx < 5) {
+      group.add(Marine());
+    } else {
+      group.add(Medic());
+    }
+    idx++;
+  }
+  print('마린의 개수 : ${group.whereType<Marine>().length}');
+  print('메딕의 개수 : ${group.whereType<Medic>().length}');
+}

--- a/lib/06_polymorphism/starcraft/object/object.dart
+++ b/lib/06_polymorphism/starcraft/object/object.dart
@@ -1,0 +1,5 @@
+abstract class StarObject {
+  int get hp;
+  set hp(int value);
+  int get maxHp;
+}

--- a/lib/06_polymorphism/starcraft/object/unit/protoss/dragun.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/protoss/dragun.dart
@@ -1,0 +1,65 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/tribe/protoss.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/attack_unit.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/mechanic.dart';
+
+import '../../../type/unit_type/unit.dart';
+
+final dragunHp = 150;
+final dragunShield = 100;
+final dragunDamage = 20;
+
+class Dragun extends Protoss implements AttackUnit, Mechanic {
+  int _hp;
+  int _shield;
+  int _damage;
+
+  Dragun()
+      : _hp = dragunHp,
+        _shield = dragunShield,
+        _damage = dragunDamage;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get maxHp => dragunHp;
+
+  @override
+  int get shield => _shield;
+
+  @override
+  set shield(int value) {
+    _shield = value;
+  }
+
+  @override
+  int get maxShield => dragunShield;
+
+  @override
+  int get damage => _damage;
+
+  @override
+  set damage(int value) {
+    _damage = value;
+  }
+
+  @override
+  void attack(Unit target) {
+    // TODO: implement attack
+  }
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+
+  @override
+  void chargeShield() {
+    shield += 1;
+  }
+}

--- a/lib/06_polymorphism/starcraft/object/unit/protoss/zealot.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/protoss/zealot.dart
@@ -1,0 +1,66 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/attack_unit.dart';
+
+import '../../../tribe/protoss.dart';
+import '../../../type/bionic.dart';
+import '../../../type/unit_type/unit.dart';
+
+final zelotShield = 50;
+final zelotHp = 100;
+final zelotDamage = 16;
+
+class Zealot extends Protoss implements AttackUnit, Bionic {
+  int _shield;
+  int _hp;
+  int _damage;
+
+  Zealot()
+      : _shield = zelotShield,
+        _hp = zelotHp,
+        _damage = zelotDamage;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get maxHp => zelotHp;
+
+  @override
+  int get shield => _shield;
+
+  @override
+  int get maxShield => zelotShield;
+
+  @override
+  set shield(int value) {
+    _shield = value;
+  }
+
+  @override
+  int get damage => _damage;
+
+  @override
+  set damage(int value) {
+    _damage = value;
+  }
+
+  @override
+  void attack(Unit target) {
+    // TODO: implement attack
+  }
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+
+  @override
+  void chargeShield() {
+    // 주기적으로 쉴드 회복...
+    shield += 1;
+  }
+}

--- a/lib/06_polymorphism/starcraft/object/unit/terran/marine.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/terran/marine.dart
@@ -1,0 +1,47 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/tribe/terran.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/attack_unit.dart';
+
+import '../../../type/bionic.dart';
+import '../../../type/unit_type/unit.dart';
+
+
+final marineHp = 40;
+final marineDamage = 6;
+
+class Marine extends Terran implements AttackUnit, Bionic {
+  int _hp;
+  int _damage;
+
+  Marine()
+      : _hp = marineHp,
+        _damage = marineDamage;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get maxHp => marineHp;
+
+  @override
+  int get damage => _damage;
+
+  @override
+  set damage(int value) {
+    _damage = value;
+  }
+
+  @override
+  void attack(Unit target) {
+    // TODO: implement attack
+  }
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+}

--- a/lib/06_polymorphism/starcraft/object/unit/terran/medic.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/terran/medic.dart
@@ -1,0 +1,62 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/tribe/terran.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/magic_unit.dart';
+
+import '../../../type/bionic.dart';
+import '../../../type/unit_type/unit.dart';
+
+final medicHp = 40;
+final medicMp = 250;
+
+class Medic extends Terran implements MagicUnit, Bionic {
+  int _hp;
+  int _mp;
+
+  Medic()
+      : _hp = medicHp,
+        _mp = medicMp;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get mp => _mp;
+
+  @override
+  set mp(int value) {
+    _mp = value;
+  }
+
+  @override
+  // TODO: implement maxHp
+  int get maxHp => medicHp;
+
+  @override
+  // TODO: implement maxMp
+  int get maxMp => medicMp;
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+
+  void heal(Unit target) {
+    if (target is! Bionic) {
+      print('${target.toString()}은 힐 불가');
+      return;
+    }
+
+    target.hp += 1;
+  }
+
+  @override
+  void useMagic({Unit? target}) {
+    if (target != null) {
+      heal(target);
+    }
+  }
+}

--- a/lib/06_polymorphism/starcraft/object/unit/terran/scv.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/terran/scv.dart
@@ -1,0 +1,64 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/tribe/terran.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/mechanic.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/attack_unit.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/magic_unit.dart';
+
+import '../../../type/bionic.dart';
+import '../../../type/unit_type/unit.dart';
+
+final scvHp = 60;
+final scvDamage = 5;
+
+class Scv extends Terran implements AttackUnit, Bionic, Mechanic {
+  int _hp;
+  int _damage;
+
+  Scv()
+      : _hp = scvHp,
+        _damage = scvDamage;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  int get maxHp => scvHp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get damage => _damage;
+
+  @override
+  set damage(int value) {
+    _damage = value;
+  }
+
+  @override
+  void attack(Unit target) {
+    // TODO: implement attack
+  }
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+
+  void containMineral() {}
+
+  void repair(Unit target) {
+    if (identical(this, target)) {
+      print('자가 치료는 불가합니다.');
+      return;
+    }
+
+    if (target is! Mechanic) {
+      print('수리가 불가능 합니다.');
+      return;
+    }
+
+    target.hp += 1;
+  }
+}

--- a/lib/06_polymorphism/starcraft/object/unit/zerg/zergling.dart
+++ b/lib/06_polymorphism/starcraft/object/unit/zerg/zergling.dart
@@ -1,0 +1,52 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/tribe/zerg.dart';
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/attack_unit.dart';
+
+import '../../../type/bionic.dart';
+import '../../../type/unit_type/unit.dart';
+
+final zerglingHp = 40;
+final zerglingDamage = 5;
+
+class Zergling extends Zerg implements AttackUnit, Bionic {
+  int _hp;
+  int _damage;
+
+  Zergling()
+      : _hp = zerglingHp,
+        _damage = zerglingDamage;
+
+  @override
+  int get hp => _hp;
+
+  @override
+  set hp(int value) {
+    _hp = value;
+  }
+
+  @override
+  int get maxHp => zerglingHp;
+
+  @override
+  int get damage => _damage;
+
+  @override
+  set damage(int value) {
+    _damage = value;
+  }
+
+  @override
+  void attack(Unit target) {
+    // TODO: implement attack
+  }
+
+  @override
+  void move() {
+    // TODO: implement move
+  }
+
+  @override
+  void selfAid() {
+    // 주기적으로 hp 회복...
+    hp += 1;
+  }
+}

--- a/lib/06_polymorphism/starcraft/starcraft.puml
+++ b/lib/06_polymorphism/starcraft/starcraft.puml
@@ -1,0 +1,81 @@
+@startuml
+
+abstract class Object {
+    + String name
+}
+
+abstract class Terran extends Object
+abstract class Zerg extends Object
+abstract class Protoss extends Object
+
+interface Bionic
+interface Mechanic
+interface Unit implements Moveable {
+}
+interface Structure {
+}
+interface Attackable {
+    + void attack()
+}
+interface Healable {
+    + void heal(Bionic bionic)
+}
+interface Shieldable
+interface Collectable {
+    + void collect()
+}
+interface Repairable {
+    + void repair()
+}
+interface Generatable {
+    + void generate()
+}
+interface SelfAidable {
+    + void selfAid()
+}
+interface Moveable {
+    + void move()
+}
+
+interface Structure implements Generatable {
+}
+
+class ProtossStructure extends Protoss implements Structure, Mechanic, Shieldable {
+
+}
+
+class ZergStructure extends Zerg implements Structure, Bionic, SelfAidable{
+}
+
+class TerranStructure extends Terran implements Structure, Mechanic {
+
+}
+
+class Marine extends Terran implements Unit, Bionic, Attackable {
+}
+
+class Medic extends Terran implements Unit, Bionic, Healable {
+}
+
+class Vulture extends Terran implements Unit, Mechanic, Attackable{
+}
+
+class Tank extends Terran implements Unit, Mechanic, Attackable {
+}
+
+class SCV extends Terran implements Unit, Bionic, Mechanic, Attackable, Collectable, Repairable {
+}
+
+class Zergling extends Zerg implements Unit, Bionic, Attackable, SelfAidable {
+}
+
+class Hydra extends Zerg implements Unit, Bionic, Attackable, SelfAidable {
+}
+
+class Zealot extends Protoss implements Unit, Bionic, Attackable, Shieldable {
+}
+
+class Dragun extends Protoss implements Unit, Mechanic, Attackable, Shieldable {
+}
+
+@enduml

--- a/lib/06_polymorphism/starcraft/tribe/protoss.dart
+++ b/lib/06_polymorphism/starcraft/tribe/protoss.dart
@@ -1,0 +1,7 @@
+abstract class Protoss {
+  int get shield;
+  int get maxShield;
+  set shield(int value);
+
+  void chargeShield();
+}

--- a/lib/06_polymorphism/starcraft/tribe/terran.dart
+++ b/lib/06_polymorphism/starcraft/tribe/terran.dart
@@ -1,0 +1,2 @@
+abstract class Terran {
+}

--- a/lib/06_polymorphism/starcraft/tribe/zerg.dart
+++ b/lib/06_polymorphism/starcraft/tribe/zerg.dart
@@ -1,0 +1,3 @@
+abstract class Zerg {
+  void selfAid();
+}

--- a/lib/06_polymorphism/starcraft/type/bionic.dart
+++ b/lib/06_polymorphism/starcraft/type/bionic.dart
@@ -1,0 +1,3 @@
+abstract interface class Bionic {
+
+}

--- a/lib/06_polymorphism/starcraft/type/mechanic.dart
+++ b/lib/06_polymorphism/starcraft/type/mechanic.dart
@@ -1,0 +1,3 @@
+abstract interface class Mechanic {
+
+}

--- a/lib/06_polymorphism/starcraft/type/structure.dart
+++ b/lib/06_polymorphism/starcraft/type/structure.dart
@@ -1,0 +1,5 @@
+import 'package:learn_dart_together/06_polymorphism/starcraft/type/unit_type/unit.dart';
+
+abstract interface class Structure extends Object {
+  void generate(Unit unit);
+}

--- a/lib/06_polymorphism/starcraft/type/unit_type/attack_unit.dart
+++ b/lib/06_polymorphism/starcraft/type/unit_type/attack_unit.dart
@@ -1,0 +1,9 @@
+import 'unit.dart';
+
+abstract class AttackUnit extends Unit {
+  int get damage;
+
+  set damage(int value);
+
+  void attack(Unit target);
+}

--- a/lib/06_polymorphism/starcraft/type/unit_type/magic_unit.dart
+++ b/lib/06_polymorphism/starcraft/type/unit_type/magic_unit.dart
@@ -1,0 +1,11 @@
+import 'unit.dart';
+
+abstract class MagicUnit extends Unit {
+  int get mp;
+
+  int get maxMp;
+
+  set mp(int value);
+
+  void useMagic({Unit target});
+}

--- a/lib/06_polymorphism/starcraft/type/unit_type/unit.dart
+++ b/lib/06_polymorphism/starcraft/type/unit_type/unit.dart
@@ -1,0 +1,5 @@
+import '../../object/object.dart';
+
+abstract class Unit extends StarObject {
+  void move();
+}


### PR DESCRIPTION
* 연습문제 2,3 제출합니다.
* 그룹 과제 외 따로 코딩하며 제작한 uml도 첨부합니다.
- field가 없는 class는 interface로
- 웬만하면 extends로 상속받게 하였으며 field가 있으면 abstract class로 작성하려 했습니다.
- MagicUnit과 AttackUnit을 implment로 받은 이유는 동시에 존재할 수 있기 때문입니다.
- 종족 값은 중복될 수 없기 때문에 extends로 받았습니다.  
- 솔직히 abstract class와 abstract interface class의 차이가 뭔지 잘 모르겠습니다.